### PR TITLE
Move image to the round circle

### DIFF
--- a/blocks/squote2.php
+++ b/blocks/squote2.php
@@ -20,31 +20,31 @@ $link = get_field('link');
 						echo wpautop($quote);
 						echo '</div>';
 					}
-					echo '<div class="rest">';
-					if (!empty($img)) {
-						echo '<img src="' . $img . '" alt=""/>';
-					}
-					echo '</div>';
-					?>
+                    <?php
+                    if (!empty($text)) {
+                        echo '<p>' . $text . '</p>';
+                    }
+                    if ($link) {
+                        $link_url = $link['url'];
+                        $link_title = $link['title'];
+                        $link_target = $link['target'] ? $link['target'] : '_self';
+                        echo '<a class="c-btn btn-black" href="' . esc_url($link_url) . '" target="' . esc_attr($link_target) . '">' . esc_html($link_title) . '</a>';
+                    }
+                    ?>
 				</div>
 			</div>
-			<div class="col-lg-5 order-lg-1">
-				<div class="round-block">
-					<div class="round-inner">
-						<?php
-						if (!empty($text)) {
-							echo '<p>' . $text . '</p>';
-						}
-						if ($link) {
-							$link_url = $link['url'];
-							$link_title = $link['title'];
-							$link_target = $link['target'] ? $link['target'] : '_self';
-							echo '<a class="c-btn btn-black" href="' . esc_url($link_url) . '" target="' . esc_attr($link_target) . '">' . esc_html($link_title) . '</a>';
-						}
-						?>
-					</div>
-				</div>
-			</div>
+            if (!empty($img)) {
+                echo '<div class="col-lg-5 order-lg-1">
+                    <div class="round-block">
+                        <div class="round-inner">
+                            <div class="rest">';
+                                echo '<img src="' . $img . '" alt="logo"/>';
+                                echo '</div>
+                        </div>
+                    </div>
+                </div>';
+            }
+            ?>
 		</div>
 	</div>
 </section>


### PR DESCRIPTION
Moving the image from the bottom to the round circle. Was that not intended that way? It looks much better... The text (quote author) and link should be together with the quote, imho.

Maybe the size of the circle should be constrained in css?

What I'm trying to fix is this:
<img width="1158" alt="Screenshot_20220704_170152" src="https://user-images.githubusercontent.com/551757/177180186-95f11330-d838-4cef-8758-cc97d978442d.png">

That is absolutely terrible...