### PR TITLE
Remove skiff.com - not disposible mail

### DIFF
--- a/inc/disposable_email_blocklist_private.txt
+++ b/inc/disposable_email_blocklist_private.txt
@@ -8,7 +8,6 @@ duck.com
 gmail.de
 gettempmail.com
 anonadddy.me
-skiff.com
 mailo.fr
 kabelbw.de
 88.com


### PR DESCRIPTION
Hello! I'm removing [Skiff](https://skiff.com) as it is not a disposable email service.