### PR TITLE
False Positive: Please remove atomicmail.io from disposable list (leg…

### DIFF
--- a/inc/disposable_email_blocklist_private.txt
+++ b/inc/disposable_email_blocklist_private.txt
@@ -47,7 +47,6 @@ asda.com
 asdf.asdf
 asdf.com
 ask.com
-atomicmail.io
 b.com
 b.de
 baidu.com


### PR DESCRIPTION
Hello,

I'm the Product Manager at Atomic Mail (atomicmail.io). It looks like our domain got caught up in your disposable email blocklist, and I’m hoping to get it removed (and ideally added to allowlist).

To give some context: we are a standard, permanent encrypted email provider, not a throwaway mail service. Recently, we were targeted by a coordinated bot attack trying to mass-register accounts. It’s highly likely your automated scrapers (or a user report) caught this spike and flagged our domain.

We’ve shut that down. Here is how we actively prevent abuse on our platform:
1. We enforce strict rate limits on account creation and auth attempts per IP, along with a mandatory CAPTCHA during registration. 
2. We have hard limits on outbound email volume per account to prevent spam runs. 
3. We use continuously trained Bayesian models for inbound/outbound filtering (with additional AI-based filtering rolling out soon). 
4. Full implementation of DKIM, SPF, and DMARC.
5. Our Trust & Safety team actively reviews abuse reports and manually bans violators based on our strict zero-tolerance policy: https://atomicmail.io/privacy-policy. 
6. We operate in strict compliance with GDPR requirements, ensuring robust data privacy and proper account deletion procedures for all our users. 

For external validation, I’ve attached a screenshot from Palo Alto Networks URL Filtering confirming our domain holds a clean, 'Low-Risk' Web-based-Email reputation.

Having our domain on this list is currently blocking our real users from registering on third-party sites. Let me know if you need any server logs or further info from my side to verify this.

Thanks for your time and for maintaining this list!
<img width="1710" height="1107" alt="2026-03-20_15-54-19" src="https://github.com/user-attachments/assets/a78bee1c-b588-4ff4-b274-2964104564d1" />
